### PR TITLE
remove basic ipv6 tests inherited from basic ipv4, since won't work due ...

### DIFF
--- a/tempest/scenario/test_network_basic_ops.py
+++ b/tempest/scenario/test_network_basic_ops.py
@@ -383,7 +383,3 @@ class TestNetworkBasicOps(manager.NeutronScenarioTest):
         self._create_new_network()
         self._hotplug_server()
         self._check_network_internal_connectivity(network=self.new_net)
-
-
-class TestNetwork6BasicOps(TestNetworkBasicOps):
-    _ip_version = 6


### PR DESCRIPTION
...to attempt to assign  floating ipv4 to private ipv6

Change-Id: I91fa47e4fe3cadd41f5f989bb172960ae0dbfbdb
