### PR TITLE
Fix, add, remove IPv6 tests for DHCPv6, API

### DIFF
--- a/tempest/services/network/xml/network_client.py
+++ b/tempest/services/network/xml/network_client.py
@@ -149,7 +149,7 @@ class NetworkClientXML(client_base.NetworkClientBase):
         resp, body = self.put(uri, str(common.Document(subnet)))
         self.rest_client.expected_success(200, resp.status)
         body = _root_tag_fetcher_and_xml_to_json_parse(body)
-        return resp, body
+        return resp, body['_v_root']
 
     def add_router_interface_with_port_id(self, router_id, port_id):
         uri = '%s/routers/%s/add_router_interface' % (self.uri_prefix,


### PR DESCRIPTION
According to new functionality in review 129144
Also coverage for bugs 1382076, 1330826
Expected fails:
Test test_dhcp_stateless_router fails because 1382076
Test test_dhcpv6_stateless_two_subnets fails because 1358709
